### PR TITLE
[Bugfix] Fix a bug in LLava dataloader

### DIFF
--- a/llava/llava_data_vq_unified.py
+++ b/llava/llava_data_vq_unified.py
@@ -255,6 +255,7 @@ def get_instruct_data_loader(
     dataloader = torch.utils.data.DataLoader(
         train_dataset,
         batch_size=batch_size,
+        drop_last=True,
         num_workers=num_workers,
         pin_memory=True,
         collate_fn=partial(

--- a/llava/llava_instruct_data.py
+++ b/llava/llava_instruct_data.py
@@ -251,6 +251,7 @@ def get_instruct_data_loader(
     dataloader = torch.utils.data.DataLoader(
         train_dataset,
         batch_size=batch_size,
+        drop_last=True,
         num_workers=num_workers,
         pin_memory=True,
         collate_fn=partial(

--- a/llava/llava_pretrain_data.py
+++ b/llava/llava_pretrain_data.py
@@ -166,6 +166,7 @@ def get_plain_data_loader(
     dataloader = torch.utils.data.DataLoader(
         train_dataset,
         batch_size=batch_size,
+        drop_last=True,
         num_workers=num_workers,
         pin_memory=True,
         collate_fn=partial(


### PR DESCRIPTION
Leaving drop_last as the default value of `False` may cause an issue where the batch size is incorrectly assumed to be batch_size_mmu when calculating [loss_mmu](https://github.com/showlab/Show-o/blob/48cdb24c56034e7784d0279e65e25dbfeb9cf55d/models/modeling_showo.py#L95).